### PR TITLE
Track replayIds

### DIFF
--- a/lib/restforce/concerns/streaming.rb
+++ b/lib/restforce/concerns/streaming.rb
@@ -8,11 +8,8 @@ module Restforce
       #
       # Returns a Faye::Subscription
       def subscribe(channels, options = {}, &block)
-        topics = Array(channels).map do |channel|
-          replay_handlers[channel] = options[:replay]
-          "/topic/#{channel}"
-        end
-        faye.subscribe topics, &block
+        Array(channels).each { |channel| replay_handlers[channel] = options[:replay] }
+        faye.subscribe Array(channels).map { |channel| "/topic/#{channel}" }, &block
       end
 
       # Public: Faye client to use for subscribing to PushTopics

--- a/lib/restforce/concerns/streaming.rb
+++ b/lib/restforce/concerns/streaming.rb
@@ -8,9 +8,11 @@ module Restforce
       #
       # Returns a Faye::Subscription
       def subscribe(channels, options = {}, &block)
-        @replay = options[:replay]
-        @channels = Array(channels)
-        faye.subscribe @channels.map { |channel| "/topic/#{channel}" }, &block
+        topics = Array(channels).map do |channel|
+          replay_handlers[channel] = options[:replay]
+          "/topic/#{channel}"
+        end
+        faye.subscribe topics, &block
       end
 
       # Public: Faye client to use for subscribing to PushTopics
@@ -21,32 +23,42 @@ module Restforce
 
         url = "#{options[:instance_url]}/cometd/#{options[:api_version]}"
 
-        unless @faye
-          @faye = Faye::Client.new(url).tap do |client|
-            client.set_header 'Authorization', "OAuth #{options[:oauth_token]}"
+        @faye ||= Faye::Client.new(url).tap do |client|
+          client.set_header 'Authorization', "OAuth #{options[:oauth_token]}"
 
-            client.bind 'transport:down' do
-              Restforce.log "[COMETD DOWN]"
-              client.set_header 'Authorization', "OAuth #{authenticate!.access_token}"
-            end
-
-            client.bind 'transport:up' do
-              Restforce.log "[COMETD UP]"
-            end
+          client.bind 'transport:down' do
+            Restforce.log "[COMETD DOWN]"
+            client.set_header 'Authorization', "OAuth #{authenticate!.access_token}"
           end
 
-          if @replay
-            @faye.add_extension ReplayExtension.new(channels: @channels, replay: @replay)
+          client.bind 'transport:up' do
+            Restforce.log "[COMETD UP]"
           end
+
+          client.add_extension ReplayExtension.new(replay_handlers)
         end
+      end
 
-        @faye
+      def replay_handlers
+        @_replay_handlers ||= {}
       end
 
       class ReplayExtension
-        def initialize(options)
-          @channels = options[:channels]
-          @replay = options[:replay]
+        def initialize(replay_handlers)
+          @replay_handlers = replay_handlers
+        end
+
+        def incoming(message, callback)
+          channel = message.fetch('channel').gsub('/topic/', '')
+          replay_id = message.fetch('data', {}).fetch('event', {})['replayId']
+
+          handler = @replay_handlers[channel]
+          if !replay_id.nil? && !handler.nil? && handler.respond_to?(:[]=)
+            # remember the last replay_id for this channel
+            handler[channel] = replay_id
+          end
+
+          callback.call(message)
         end
 
         def outgoing(message, callback)
@@ -55,16 +67,34 @@ module Restforce
             return callback.call(message)
           end
 
-          # Set the replay value for the each channel
+          channel = message['subscription'].gsub('/topic/', '')
+
+          # Set the replay value for the channel
           message['ext'] ||= {}
-          message['ext']['replay'] = {}
-          @channels.each do |channel|
-            message['ext']['replay']["/topic/#{channel}"] = @replay
-          end
+          message['ext']['replay'] = {
+            "/topic/#{channel}" => replay_id(channel)
+          }
 
           # Carry on and send the message to the server
           callback.call message
         end
+
+        private
+
+        def replay_id(channel)
+          handler = @replay_handlers[channel]
+          case
+          when handler.is_a?(Integer)
+            handler # treat it as a scalar
+          when handler.respond_to?(:[])
+            # Ask for the latest replayId for this channel
+            handler[channel]
+          else
+            # Just pass it along
+            handler
+          end
+        end
+
       end
     end
   end

--- a/spec/unit/concerns/streaming_spec.rb
+++ b/spec/unit/concerns/streaming_spec.rb
@@ -15,6 +15,35 @@ describe Restforce::Concerns::Streaming, event_machine: true do
 
       client.subscribe(channels, &subscribe_block)
     end
+
+    context "replay_handlers" do
+
+      before {
+        faye_double.should_receive(:subscribe).at_least(1)
+        client.stub faye: faye_double
+      }
+
+      it 'registers nil handlers when no replay option is given' do
+        client.subscribe(channels, &subscribe_block)
+        client.replay_handlers.should eq('channel1' => nil, 'channel2' => nil)
+      end
+
+      it 'registers a replay_handler for each channel given' do
+        client.subscribe(channels, replay: -2, &subscribe_block)
+        client.replay_handlers.should eq('channel1' => -2, 'channel2' => -2)
+      end
+
+      it 'replaces earlier handlers in subsequent calls' do
+        client.subscribe(%w(channel1 channel2), replay: 2, &subscribe_block)
+        client.subscribe(%w(channel2 channel3), replay: 3, &subscribe_block)
+        client.replay_handlers.should eq(
+          'channel1' => 2,
+          'channel2' => 3,
+          'channel3' => 3
+        )
+      end
+
+    end
   end
 
   describe '.faye' do
@@ -40,6 +69,7 @@ describe Restforce::Concerns::Streaming, event_machine: true do
         faye_double.should_receive(:set_header).with('Authorization', 'OAuth secret2')
         faye_double.should_receive(:bind).with('transport:down').and_yield
         faye_double.should_receive(:bind).with('transport:up').and_yield
+        faye_double.should_receive(:add_extension).with(kind_of(Restforce::Concerns::Streaming::ReplayExtension))
         subject
       end
     end
@@ -49,5 +79,90 @@ describe Restforce::Concerns::Streaming, event_machine: true do
         expect { subject }.to raise_error
       end
     end
+
+  end
+
+  describe Restforce::Concerns::Streaming::ReplayExtension do
+    let(:handlers) { {} }
+    let(:extension) { Restforce::Concerns::Streaming::ReplayExtension.new(handlers) }
+
+    it 'sends nil without a specified handler' do
+      output = subscribe(extension, to: "channel1")
+      read_replay(output).should eq('/topic/channel1' => nil)
+    end
+
+    it 'with a scalar replay id' do
+      handlers['channel1'] = -2
+      output = subscribe(extension, to: "channel1")
+      read_replay(output).should eq('/topic/channel1' => -2)
+    end
+
+    it 'with a hash' do
+      hash_handler = { 'channel1' => -1, 'channel2' => -2 }
+
+      handlers['channel1'] = hash_handler
+      handlers['channel2'] = hash_handler
+
+      output = subscribe(extension, to: "channel1")
+      read_replay(output).should eq('/topic/channel1' => -1)
+
+      output = subscribe(extension, to: "channel2")
+      read_replay(output).should eq('/topic/channel2' => -2)
+    end
+
+    it 'with an object' do
+      custom_handler = double('custom_handler')
+      custom_handler.should_receive(:[]).and_return(123)
+      handlers['channel1'] = custom_handler
+
+      output = subscribe(extension, to: "channel1")
+      read_replay(output).should eq('/topic/channel1' => 123)
+    end
+
+    it 'remembers the last replayId' do
+      handler = { 'channel1' => 41 }
+      handlers['channel1'] = handler
+      message = {
+        'channel' => '/topic/channel1',
+        'data' => {
+          'event' => { 'replayId' => 42 }
+        }
+      }
+
+      extension.incoming(message, -> m { })
+      handler.should eq('channel1' => 42)
+    end
+
+    it 'when an incoming message has no replayId' do
+      handler = { 'channel1' => 41 }
+      handlers['channel1'] = handler
+
+      message = {
+        'channel' => '/topic/channel1',
+        'data' => {}
+      }
+
+      extension.incoming(message, -> m { })
+      handler.should eq('channel1' => 41)
+    end
+
+    private
+
+    def subscribe(extension, to:)
+      output = nil
+      message = {
+        'channel' => '/meta/subscribe',
+        'subscription' => "/topic/#{to}"
+      }
+      extension.outgoing(message, -> m {
+        output = m
+      })
+      output
+    end
+
+    def read_replay(message)
+      message.fetch('ext', {})['replay']
+    end
+
   end
 end


### PR DESCRIPTION
This allows the replay option passed to remember the last replayId and
to allow each channel to have it's own replay_id

The replay object supports hash-like access and can be used to provide
static values per channel using a Hash. Or if dynamic behaviour is
needed the caller can provide a custom object that responds to [] and
[]=

@panozzaj It seemed like it was safe to send 1 channel per subscribe message, is this right or have I just created a bug?